### PR TITLE
Adjust hero h1 styles subtly

### DIFF
--- a/src/components/pages/landing/Hero.tsx
+++ b/src/components/pages/landing/Hero.tsx
@@ -26,7 +26,7 @@ export const Hero = () => {
           {t("tagline")}
         </span>
 
-        <h1 className="text-4xl md:text-6xl font-bold text-foreground tracking-tight rtl:leading-snug">
+        <h1 className="mt-4 text-4xl md:text-6xl font-bold text-foreground text-balance tracking-tight rtl:leading-snug">
           {t("heading")}
         </h1>
 


### PR DESCRIPTION
Added `text-wrap: balance` and top margin to the landing page's hero `h1`.